### PR TITLE
GH-30 Add `@OpenApiExample` annotation

### DIFF
--- a/javalin-redoc-plugin/src/main/kotlin/io/javalin/openapi/plugin/redoc/ReDocHandler.kt
+++ b/javalin-redoc-plugin/src/main/kotlin/io/javalin/openapi/plugin/redoc/ReDocHandler.kt
@@ -15,7 +15,7 @@ class ReDocHandler(
     override fun handle(context: Context) {
         context
             .html(createReDocUI())
-            .res.characterEncoding = "UTF-8"
+            .res().characterEncoding = "UTF-8"
     }
 
     private fun createReDocUI(): String {

--- a/javalin-redoc-plugin/src/main/kotlin/io/javalin/openapi/plugin/redoc/ReDocWebJarHandler.kt
+++ b/javalin-redoc-plugin/src/main/kotlin/io/javalin/openapi/plugin/redoc/ReDocWebJarHandler.kt
@@ -17,7 +17,7 @@ internal class ReDocWebJarHandler(private val redocWebJarPath: String) : Handler
 
         context.result(resource)
             .contentType(MimeTypes.getDefaultMimeByExtension(context.path()))
-            .res.characterEncoding = "UTF-8"
+            .res().characterEncoding = "UTF-8"
     }
 
 }

--- a/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerHandler.kt
+++ b/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerHandler.kt
@@ -16,7 +16,7 @@ class SwaggerHandler(
     override fun handle(context: Context) {
         context
             .html(createSwaggerUiHtml())
-            .res
+            .res()
             .characterEncoding = "UTF-8"
     }
 

--- a/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerWebJarHandler.kt
+++ b/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerWebJarHandler.kt
@@ -17,7 +17,7 @@ internal class SwaggerWebJarHandler(private val swaggerWebJarPath: String) : Han
 
         context.result(resource)
             .contentType(MimeTypes.getDefaultMimeByExtension(context.path()))
-            .res.characterEncoding = "UTF-8"
+            .res().characterEncoding = "UTF-8"
     }
 
 }

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
@@ -240,11 +240,7 @@ internal class OpenApiGenerator {
         }
     }
 
-    private fun addSchema(schema: JsonObject, typeMirror: TypeMirror, isArray: Boolean) {
-        addSchema(schema, typeMirror, isArray, "")
-    }
-
-    private fun addSchema(schema: JsonObject, typeMirror: TypeMirror, isArray: Boolean, exampleValue: String?) {
+    private fun addSchema(schema: JsonObject, typeMirror: TypeMirror, isArray: Boolean, exampleValue: String? = null) {
         val type = TypesUtils.getType(typeMirror)
 
         if (isArray || type.isArray()) {

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
@@ -187,18 +187,11 @@ internal class OpenApiGenerator {
                             ?.let { OpenApiPropertyTypeInstance(it).definedBy() }
                             ?: property.returnType
 
-                        var exampleValue = String()
                         val exampleProperty = property.getAnnotation(OpenApiExample::class.java)
-                        if(exampleProperty == null)
-                        {
-                            exampleValue = ""
-                        }
-                        else{
-                            exampleValue = exampleProperty.value.toString()
-                        }
+                            ?.value
 
                         val propertyEntry = JsonObject()
-                        addSchema(propertyEntry, propertyType, false, exampleValue)
+                        addSchema(propertyEntry, propertyType, false, exampleProperty)
                         properties.add(name, propertyEntry)
                     }
                 }
@@ -251,7 +244,7 @@ internal class OpenApiGenerator {
         addSchema(schema, typeMirror, isArray, "")
     }
 
-    private fun addSchema(schema: JsonObject, typeMirror: TypeMirror, isArray: Boolean, exampleValue: String) {
+    private fun addSchema(schema: JsonObject, typeMirror: TypeMirror, isArray: Boolean, exampleValue: String?) {
         val type = TypesUtils.getType(typeMirror)
 
         if (isArray || type.isArray()) {
@@ -259,13 +252,11 @@ internal class OpenApiGenerator {
             val items = JsonObject()
             addType(items, typeMirror)
             schema.add("items", items)
-        }
-        else {
+        } else {
             addType(schema, typeMirror)
         }
 
-        if("" != exampleValue)
-        {
+        if (exampleValue != null) {
             schema.addProperty("example", exampleValue)
         }
     }

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/annotations/OpenApiParamInstance.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/annotations/OpenApiParamInstance.kt
@@ -28,6 +28,8 @@ internal class OpenApiParamInstance(mirror: AnnotationMirror) : AnnotationMirror
     fun required(): Boolean =
         getBoolean("required")
 
+    fun example(): String = getString("example")
+
     fun type(): TypeMirror =
         getType("type")
 

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/annotations/OpenApiParamInstance.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/annotations/OpenApiParamInstance.kt
@@ -28,7 +28,8 @@ internal class OpenApiParamInstance(mirror: AnnotationMirror) : AnnotationMirror
     fun required(): Boolean =
         getBoolean("required")
 
-    fun example(): String = getString("example")
+    fun example(): String =
+        getString("example")
 
     fun type(): TypeMirror =
         getType("type")

--- a/openapi-annotations/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
+++ b/openapi-annotations/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
@@ -55,7 +55,8 @@ annotation class OpenApiParam(
     val deprecated: Boolean = false,
     val required: Boolean = false,
     val allowEmptyValue: Boolean = false,
-    val isRepeatable: Boolean = false
+    val isRepeatable: Boolean = false,
+    val example: String = ""
 )
 
 @Target()
@@ -108,6 +109,11 @@ annotation class OpenApiIgnore
 
 @Target(FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
 annotation class OpenApiName(
+    val value: String
+)
+
+@Target(FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
+annotation class OpenApiExample(
     val value: String
 )
 

--- a/openapi-test/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
+++ b/openapi-test/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
@@ -6,6 +6,7 @@ import io.javalin.http.Handler;
 import io.javalin.openapi.HttpMethod;
 import io.javalin.openapi.OpenApi;
 import io.javalin.openapi.OpenApiContent;
+import io.javalin.openapi.OpenApiExample;
 import io.javalin.openapi.OpenApiIgnore;
 import io.javalin.openapi.OpenApiName;
 import io.javalin.openapi.OpenApiParam;
@@ -19,7 +20,11 @@ import io.javalin.openapi.plugin.redoc.ReDocPlugin;
 import io.javalin.openapi.plugin.swagger.SwaggerConfiguration;
 import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
 import org.jetbrains.annotations.NotNull;
+
 import java.io.Serializable;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 
@@ -72,7 +77,9 @@ public final class JavalinTest implements Handler {
             ),
             headers = {
                     @OpenApiParam(name = "Authorization", description = "Alias and token provided as basic auth credentials", required = true, type = UUID.class),
-                    @OpenApiParam(name = "Optional")
+                    @OpenApiParam(name = "Optional"),
+                    @OpenApiParam(name = "X-Rick", example = "Rolled"),
+                    @OpenApiParam(name = "X-SomeNumber", required = true, type = Integer.class, example = "500")
             },
             pathParams = {
                     @OpenApiParam(name = "name", description = "Name", required = true, type = UUID.class)
@@ -97,6 +104,7 @@ public final class JavalinTest implements Handler {
 
         private final int status;
         private final String message;
+        private final String timestamp;
         private final Foo foo;
         private final List<Foo> foos;
         private Bar bar;
@@ -107,6 +115,7 @@ public final class JavalinTest implements Handler {
             this.foo = foo;
             this.foos = foos;
             this.bar = bar;
+            this.timestamp = ZonedDateTime.now( ZoneOffset.UTC ).format( DateTimeFormatter.ISO_INSTANT );
         }
 
         // should ignore
@@ -147,15 +156,31 @@ public final class JavalinTest implements Handler {
             return status + message;
         }
 
+        // should contain example
+        @OpenApiExample(value = "2022-08-14T21:13:03.546Z")
+        public String getTimestamp() {
+            return timestamp;
+        }
+
+        // should contain example for primitive types, SwaggerUI will automatically display this as an Integer
+        @OpenApiExample(value = "5050")
+        public int getVeryImportantNumber() {
+            return status + 1;
+        }
     }
 
     static final class Foo {
 
         private String property;
 
+        private String link;
+
         public String getProperty() {
             return property;
         }
+
+        @OpenApiExample(value = "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        public String getLink(){ return link; }
 
     }
 

--- a/openapi-test/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
+++ b/openapi-test/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
@@ -157,13 +157,13 @@ public final class JavalinTest implements Handler {
         }
 
         // should contain example
-        @OpenApiExample(value = "2022-08-14T21:13:03.546Z")
+        @OpenApiExample("2022-08-14T21:13:03.546Z")
         public String getTimestamp() {
             return timestamp;
         }
 
         // should contain example for primitive types, SwaggerUI will automatically display this as an Integer
-        @OpenApiExample(value = "5050")
+        @OpenApiExample("5050")
         public int getVeryImportantNumber() {
             return status + 1;
         }
@@ -179,8 +179,10 @@ public final class JavalinTest implements Handler {
             return property;
         }
 
-        @OpenApiExample(value = "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        public String getLink(){ return link; }
+        @OpenApiExample("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        public String getLink() {
+            return link;
+        }
 
     }
 


### PR DESCRIPTION
Adds support for annotations to specify `example` fields in the generated OpenAPI spec. 

Example in SwaggerUI:
![image](https://user-images.githubusercontent.com/8269353/183304030-8339b537-04f6-433a-b5f4-ba54ed80ebf1.png)
