### PR TITLE
GH-31 Add extended OpenAPI info configuration

### DIFF
--- a/javalin-openapi-plugin/src/main/kotlin/io/javalin/openapi/plugin/OpenApiPlugin.kt
+++ b/javalin-openapi-plugin/src/main/kotlin/io/javalin/openapi/plugin/OpenApiPlugin.kt
@@ -9,12 +9,58 @@ import io.javalin.plugin.json.JavalinJackson.Companion.defaultMapper
 import org.slf4j.LoggerFactory
 
 class OpenApiConfiguration {
-    var title = "OpenApi Title"
-    var description = "OpenApi Description"
-    var version = "OpenApi Version"
+    var info: OpenApiInfo = OpenApiInfo()
     var documentationPath = "/openapi"
     var documentProcessor: ((ObjectNode) -> String)? = null
     var security: SecurityConfiguration? = null
+}
+
+// https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#infoObject
+class OpenApiInfo {
+    // REQUIRED. The title of the API
+    var title = "OpenApi Title"
+
+    // A short summary of the API
+    var summary: String? = null
+
+    // A description of the API. CommonMark syntax MAY be used for rich text representation
+    var description: String? = null
+
+    // A URL to the Terms of Service for the API. This MUST be in the form of a URL.
+    var termsOfService: String? = null
+
+    // The contact information for the exposed API
+    var contact: OpenApiContact? = null
+
+    // The license information for the exposed API
+    var license: OpenApiLicense? = null
+
+    // REQUIRED. The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API implementation version).
+    var version = ""
+}
+
+// https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#contactObject
+class OpenApiContact {
+    // The identifying name of the contact person/organization.
+    var name: String? = null
+
+    // The URL pointing to the contact information. This MUST be in the form of a URL.
+    var url: String? = null
+
+    // The email address of the contact person/organization. This MUST be in the form of an email address.
+    var email: String? = null
+}
+
+// https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#licenseObject
+class OpenApiLicense {
+    // REQUIRED. The license name used for the API
+    var name = ""
+
+    // An SPDX license expression for the API. The identifier field is mutually exclusive of the url field.
+    var identifier: String? = null
+
+    // A URL to the license used for the API. This MUST be in the form of a URL. The url field is mutually exclusive of the identifier field
+    var url: String? = null
 }
 
 class OpenApiPlugin(private val configuration: OpenApiConfiguration) : Plugin, PluginLifecycleInit {
@@ -24,24 +70,24 @@ class OpenApiPlugin(private val configuration: OpenApiConfiguration) : Plugin, P
 
     override fun init(app: Javalin) {
         this.documentation = readResource("/openapi.json")
-            ?.replaceFirst("{openapi.title}", configuration.title)
-            ?.replaceFirst("{openapi.description}", configuration.description)
-            ?.replaceFirst("{openapi.version}", configuration.version)
             ?.let { modifyDocumentation(it) }
     }
 
     private fun modifyDocumentation(rawDocs: String): String =
         with(configuration) {
-            if (documentProcessor == null && security == null) {
-                return rawDocs
-            }
-
             val docsNode = defaultMapper().readTree(rawDocs) as ObjectNode
+
+            //process OpenAPI field "info"
+            docsNode.replace("info", defaultMapper().convertValue(info, JsonNode::class.java))
+
+            //process OpenAPI field "components"
             val componentsNode = docsNode.get("components") as? ObjectNode? ?: defaultMapper().createObjectNode().also { docsNode.replace("components", it) }
 
+            //process OpenAPI field "securitySchemes"
             val securitySchemes = security?.securitySchemes ?: emptyMap()
             componentsNode.replace("securitySchemes", defaultMapper().convertValue(securitySchemes, JsonNode::class.java))
 
+            //process OpenAPI field "security"
             val securityMap = security?.globalSecurity?.associate { it.name to it.scopes.toTypedArray() }
             docsNode.replace("security", defaultMapper().convertValue(securityMap, JsonNode::class.java))
 

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
@@ -42,13 +42,6 @@ internal class OpenApiGenerator {
         val openApi = JsonObject()
         openApi.addProperty("openapi", "3.0.3")
 
-        // somehow fill info { description, version } properties
-        val info = JsonObject()
-        info.addProperty("title", "{openapi.title}")
-        info.addProperty("description", "{openapi.description}")
-        info.addProperty("version", "{openapi.version}")
-        openApi.add("info", info)
-
         // fill paths
         val paths = JsonObject()
         openApi.add("paths", paths)

--- a/openapi-test/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
+++ b/openapi-test/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
@@ -24,6 +24,9 @@ import io.javalin.openapi.plugin.CookieAuth;
 import io.javalin.openapi.plugin.ImplicitFlow;
 import io.javalin.openapi.plugin.OAuth2;
 import io.javalin.openapi.plugin.OpenApiConfiguration;
+import io.javalin.openapi.plugin.OpenApiContact;
+import io.javalin.openapi.plugin.OpenApiInfo;
+import io.javalin.openapi.plugin.OpenApiLicense;
 import io.javalin.openapi.plugin.OpenApiPlugin;
 import io.javalin.openapi.plugin.OpenID;
 import io.javalin.openapi.plugin.Security;
@@ -59,8 +62,26 @@ public final class JavalinTest implements Handler {
         Javalin.create(config -> {
             String deprecatedDocsPath = "/swagger-docs";
 
+            OpenApiContact openApiContact = new OpenApiContact();
+            openApiContact.setName("API Support");
+            openApiContact.setUrl("https://www.example.com/support");
+            openApiContact.setEmail("support@example.com");
+
+            OpenApiLicense openApiLicense = new OpenApiLicense();
+            openApiLicense.setName("Apache 2.0");
+            openApiLicense.setIdentifier("Apache-2.0");
+
+            OpenApiInfo openApiInfo = new OpenApiInfo();
+            openApiInfo.setTitle("Awesome App");
+            openApiInfo.setSummary("App summary");
+            openApiInfo.setDescription("App description goes right here");
+            openApiInfo.setTermsOfService("https://example.com/tos");
+            openApiInfo.setContact(openApiContact);
+            openApiInfo.setLicense(openApiLicense);
+            openApiInfo.setVersion("1.0.0");
+
             OpenApiConfiguration openApiConfiguration = new OpenApiConfiguration();
-            openApiConfiguration.setTitle("AwesomeApp");
+            openApiConfiguration.setInfo(openApiInfo);
             openApiConfiguration.setDocumentationPath(deprecatedDocsPath); // by default it's /openapi
             // Based on official example: https://swagger.io/docs/specification/authentication/oauth2/
             openApiConfiguration.setSecurity(new SecurityConfiguration(


### PR DESCRIPTION
Adds support for an extended [OpenAPI info](https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#infoObject) configuration.

![image](https://user-images.githubusercontent.com/8269353/183514440-9dc1302b-ea6e-442f-91d7-4e4688206ab3.png)


example usage:

```
            OpenApiContact openApiContact = new OpenApiContact();
            openApiContact.setName("API Support");
            openApiContact.setUrl("https://www.example.com/support");
            openApiContact.setEmail("support@example.com");

            OpenApiLicense openApiLicense = new OpenApiLicense();
            openApiLicense.setName("Apache 2.0");
            openApiLicense.setIdentifier("Apache-2.0");

            OpenApiInfo openApiInfo = new OpenApiInfo();
            openApiInfo.setTitle("Awesome App");
            openApiInfo.setSummary("App summary");
            openApiInfo.setDescription("App description goes right here");
            openApiInfo.setTermsOfService("https://example.com/tos");
            openApiInfo.setContact(openApiContact);
            openApiInfo.setLicense(openApiLicense);
            openApiInfo.setVersion("1.0.0");

...

            openApiConfiguration.setInfo(openApiInfo);
```