### PR TITLE
GH-58 Kotlin type ByteArray is mapped to an OpenAPI integer array instead of binary string

### DIFF
--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/OpenApiGenerator.kt
@@ -319,6 +319,10 @@ internal class OpenApiGenerator {
         val model = typeMirror.toModel() ?: return
 
         when {
+            (model.type == ARRAY || isArray) && model.simpleName == "Byte" -> {
+                schema.addProperty("type", "string")
+                schema.addProperty("format", "binary")
+            }
             isArray || model.type == ARRAY -> {
                 schema.addProperty("type", "array")
                 val items = JsonObject()

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/utils/TypesUtils.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/utils/TypesUtils.kt
@@ -89,10 +89,9 @@ internal object TypesUtils {
         val model = typeMirror.toModel() ?: return ""
 
         return when {
-            model.type == ARRAY && model.simpleName == "Byte" -> "application/octet-stream"
+            (model.type == ARRAY && model.simpleName == "Byte") || model.simpleName == "[B" -> "application/octet-stream"
             model.type == ARRAY -> "application/json"
             model.simpleName == "String" -> "text/plain"
-            model.simpleName == "ByteArray" || model.simpleName == "[B" -> "application/octet-stream"
             else -> "application/json"
         }
     }

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/utils/TypesUtils.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/utils/TypesUtils.kt
@@ -89,7 +89,7 @@ internal object TypesUtils {
         val model = typeMirror.toModel() ?: return ""
 
         return when {
-            model.type == ARRAY && model.simpleName == "Byte" -> "application/json"
+            model.type == ARRAY && model.simpleName == "Byte" -> "application/octet-stream"
             model.type == ARRAY -> "application/json"
             model.simpleName == "String" -> "text/plain"
             model.simpleName == "ByteArray" || model.simpleName == "[B" -> "application/octet-stream"

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/utils/TypesUtils.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/utils/TypesUtils.kt
@@ -89,6 +89,7 @@ internal object TypesUtils {
         val model = typeMirror.toModel() ?: return ""
 
         return when {
+            model.type == ARRAY && model.simpleName == "Byte" -> "application/json"
             model.type == ARRAY -> "application/json"
             model.simpleName == "String" -> "text/plain"
             model.simpleName == "ByteArray" || model.simpleName == "[B" -> "application/octet-stream"


### PR DESCRIPTION
Closes #58 