### PR TITLE
GH-69 Support custom `validatorUrl` property

### DIFF
--- a/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerHandler.kt
+++ b/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerHandler.kt
@@ -10,7 +10,8 @@ import org.intellij.lang.annotations.Language
 class SwaggerHandler(
     private val title: String,
     private val documentationPath: String,
-    private val swaggerVersion: String
+    private val swaggerVersion: String,
+    private val validatorUrl: String?
 ) : Handler {
 
     override fun handle(context: Context) {
@@ -65,7 +66,8 @@ class SwaggerHandler(
                         plugins: [
                           SwaggerUIBundle.plugins.DownloadUrl
                         ],
-                        layout: "StandaloneLayout"
+                        layout: "StandaloneLayout",
+                        validatorUrl: ${if (validatorUrl != null) "\"$validatorUrl\"" else "null"}
                       })
                 }
                 </script>

--- a/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPlugin.kt
+++ b/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPlugin.kt
@@ -11,6 +11,7 @@ class SwaggerConfiguration {
     var uiPath = "/swagger"
     var webJarPath = "/webjars/swagger-ui"
     var documentationPath = "/openapi"
+    var validatorUrl: String? = "https://validator.swagger.io/validator"
     var roles: Array<RouteRole> = emptyArray()
 }
 
@@ -19,8 +20,10 @@ open class SwaggerPlugin @JvmOverloads constructor(private val configuration: Sw
     override fun init(app: Javalin) {}
 
     override fun apply(app: Javalin) {
+        val swaggerHandler = SwaggerHandler(configuration.title, configuration.documentationPath, configuration.version, configuration.validatorUrl)
+
         app
-            .get(configuration.uiPath, SwaggerHandler(configuration.title, configuration.documentationPath, configuration.version), *configuration.roles)
+            .get(configuration.uiPath, swaggerHandler, *configuration.roles)
             .get("${configuration.webJarPath}/*", SwaggerWebJarHandler(configuration.webJarPath), *configuration.roles)
     }
 


### PR DESCRIPTION
This will allow plugin users to configure local validators, or disable validation when the openapi file is not publicly available.

The validatorUrl property has been made nullable in order to match the SwaggerUI documentation of how the property can be set.

See https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/ for more details.