### PR TITLE
GH-151 Support path parameters in operationId generator

### DIFF
--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/generators/OpenApiGenerator.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/generators/OpenApiGenerator.kt
@@ -304,12 +304,12 @@ internal class OpenApiGenerator {
                     .map { pathPart ->
                         if (pathPart.startsWith('{') or pathPart.startsWith('<')) {
                             /* Case this is a path parameter */
-                            val pathParam = pathPart.substring(1, pathPart.length - 1)
+                            val pathParam = pathPart.drop(1).dropLast(1)
                                 .replaceFirstChar { it.titlecase(Locale.getDefault()) }
-                            return@map pathParamPrefix + pathParam
+                            pathParamPrefix + pathParam
                         } else {
                             /* Case this is a regular part of the path */
-                            return@map pathPart.replaceFirstChar {
+                            pathPart.replaceFirstChar {
                                 it.titlecase(Locale.getDefault())
                             }
                         }
@@ -317,7 +317,6 @@ internal class OpenApiGenerator {
                     .toList()
                     .joinToString(separator = "")
             }
-
             else -> openApi.operationId
         }
 

--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/generators/OpenApiGenerator.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/processor/generators/OpenApiGenerator.kt
@@ -304,14 +304,14 @@ internal class OpenApiGenerator {
                     .map { pathPart ->
                         if (pathPart.startsWith('{') or pathPart.startsWith('<')) {
                             /* Case this is a path parameter */
-                            val pathParam = pathPart.drop(1).dropLast(1)
-                                .replaceFirstChar { it.titlecase(Locale.getDefault()) }
+                            var pathParam = pathPart.drop(1).dropLast(1)
+                            /* Handling of hyphens in parameter name */
+                            pathParam = pathParam.split('-')
+                                .joinToString(separator = "") { it.capitalise() }
                             pathParamPrefix + pathParam
                         } else {
                             /* Case this is a regular part of the path */
-                            pathPart.replaceFirstChar {
-                                it.titlecase(Locale.getDefault())
-                            }
+                            pathPart.capitalise()
                         }
                     }
                     .toList()
@@ -319,6 +319,13 @@ internal class OpenApiGenerator {
             }
             else -> openApi.operationId
         }
+
+    /**
+     * String extension for capitalisation, since it's often used during operationId generation.
+     */
+    private fun String.capitalise(): String = this.replaceFirstChar {
+        it.titlecase(Locale.getDefault())
+    }
 
     private fun JsonObject.addContent(element: Element, contentAnnotations: Array<OpenApiContent>) = context.inContext {
         val requestBodyContent = JsonObject()

--- a/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/UserCasesTest.kt
+++ b/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/UserCasesTest.kt
@@ -112,4 +112,20 @@ internal class UserCasesTest : OpenApiAnnotationProcessorSpecification() {
             .isEqualTo("getApiPandaByPandaIdNameByStartsWith")
     }
 
+    /*
+    @OpenApi(
+        path = "/api/panda/{panda-id}/name/<starts-with>",
+        operationId = OpenApiOperation.AUTO_GENERATE,
+        versions = ["should_generate_operation_id_from_path_with_parameters_hyphened"]
+    )
+    @Test
+    fun should_generate_operation_id_from_path_with_parameters_hyphened() = withOpenApi("should_generate_operation_id_from_path_with_parameters_hyphened"){
+        println(it)
+        // TODO not sure what to expect here
+        assertThatJson(it)
+            .inPath("$.paths['/api/panda/{pandaId}/name/\u003cstartsWith\u003e'].get.operationId")
+            .isString
+            .isEqualTo("getApiPandaByPandaIdNameByStartsWith")
+    }
+    */
 }

--- a/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/UserCasesTest.kt
+++ b/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/UserCasesTest.kt
@@ -97,5 +97,19 @@ internal class UserCasesTest : OpenApiAnnotationProcessorSpecification() {
             .isEqualTo("getApiPandaList")
     }
 
+    @OpenApi(
+        path = "/api/panda/{pandaId}/name/<startsWith>",
+        operationId = OpenApiOperation.AUTO_GENERATE,
+        versions = ["should_generate_operation_id_from_path_with_parameters"]
+    )
+    @Test
+    fun should_generate_operation_id_from_path_with_parameters() = withOpenApi("should_generate_operation_id_from_path_with_parameters"){
+        println(it)
+
+        assertThatJson(it)
+            .inPath("$.paths['/api/panda/{pandaId}/name/\u003cstartsWith\u003e'].get.operationId")
+            .isString
+            .isEqualTo("getApiPandaByPandaIdNameByStartsWith")
+    }
 
 }

--- a/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/UserCasesTest.kt
+++ b/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/UserCasesTest.kt
@@ -1,10 +1,6 @@
 package io.javalin.openapi.processor
 
-import io.javalin.openapi.CustomAnnotation
-import io.javalin.openapi.OpenApi
-import io.javalin.openapi.OpenApiContent
-import io.javalin.openapi.OpenApiOperation
-import io.javalin.openapi.OpenApiResponse
+import io.javalin.openapi.*
 import io.javalin.openapi.processor.specification.OpenApiAnnotationProcessorSpecification
 import net.javacrumbs.jsonunit.assertj.JsonAssertions.json
 import net.javacrumbs.jsonunit.assertj.assertThatJson
@@ -107,14 +103,13 @@ internal class UserCasesTest : OpenApiAnnotationProcessorSpecification() {
         println(it)
 
         assertThatJson(it)
-            .inPath("$.paths['/api/panda/{pandaId}/name/\u003cstartsWith\u003e'].get.operationId")
+            .inPath("$.paths['/api/panda/{pandaId}/name/<startsWith>'].get.operationId")
             .isString
             .isEqualTo("getApiPandaByPandaIdNameByStartsWith")
     }
 
-    /*
     @OpenApi(
-        path = "/api/panda/{panda-id}/name/<starts-with>",
+        path = "/api/cat/{cat-id}",
         operationId = OpenApiOperation.AUTO_GENERATE,
         versions = ["should_generate_operation_id_from_path_with_parameters_hyphened"]
     )
@@ -123,9 +118,25 @@ internal class UserCasesTest : OpenApiAnnotationProcessorSpecification() {
         println(it)
         // TODO not sure what to expect here
         assertThatJson(it)
-            .inPath("$.paths['/api/panda/{pandaId}/name/\u003cstartsWith\u003e'].get.operationId")
+            .inPath("$.paths['/api/cat/{cat-id}'].get.operationId")
             .isString
-            .isEqualTo("getApiPandaByPandaIdNameByStartsWith")
+            .isEqualTo("getApiCatByCatId")
     }
-    */
+
+    @OpenApi(
+        path = "/api/panda",
+        methods= [HttpMethod.PUT],
+        operationId = OpenApiOperation.AUTO_GENERATE,
+        versions = ["should_generate_operation_id_from_path_method_put"]
+    )
+    @Test
+    fun should_generate_operation_id_from_path_method_put() = withOpenApi("should_generate_operation_id_from_path_method_put") {
+        println(it)
+
+        assertThatJson(it)
+            .inPath("$.paths['/api/panda'].put.operationId")
+            .isString
+            .isEqualTo("putApiPanda")
+    }
+
 }

--- a/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
+++ b/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
@@ -193,8 +193,6 @@ class NULL_CLASS
 
 /** Null string because annotations do not support null values */
 const val NULL_STRING = "-- This string represents a null value and shouldn't be used --"
-/** Value to use for auto-generate operationId */
-const val AUTO_STRING = "-- Auto-generate operationId on the fly. If you see this message you are either inspecting via debugger or something went wrong --"
 
 object OpenApiOperation {
     /** Value to use for auto-generate operationId */

--- a/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
+++ b/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
@@ -191,6 +191,8 @@ class NULL_CLASS
 
 /** Null string because annotations do not support null values */
 const val NULL_STRING = "-- This string represents a null value and shouldn't be used --"
+/** Value to use for auto-generate operationId */
+const val AUTO_STRING = "-- Auto-generate operationId on the fly. If you see this message you are either inspecting via debugger or something went wrong --"
 
 object ContentType {
     const val JSON = "application/json"


### PR DESCRIPTION
Following up the discussion in #151 and as an addentum to #152 , proper handling of path parameters is introduced in this PR.
Upon auto-generating operationIds, path parameters are prefixed by the keyword `By`. Basically replicating the successor plugin's behaviour and replacing their `With` by `By`.

Also added a corresponding unit test