### PR TITLE
Feature/multiple swagger uis

### DIFF
--- a/javalin-plugins/javalin-swagger-plugin/src/test/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPluginTest.kt
+++ b/javalin-plugins/javalin-swagger-plugin/src/test/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPluginTest.kt
@@ -48,4 +48,37 @@ internal class SwaggerPluginTest {
         }
     }
 
+    @Test
+    fun `should not fail if second swagger plugin is registered`(){
+        val swaggerConfiguration = SwaggerConfiguration();
+        val otherConfiguration = ExampleSwaggerPlugin();
+        Javalin.create{
+            it.plugins.register(SwaggerPlugin(swaggerConfiguration))
+            it.plugins.register(otherConfiguration)
+        }
+            .start(8080)
+            .use{
+                val response = Unirest.get("http://localhost:8080/swagger")
+                    .asString()
+                    .body
+
+                assertThat(response).contains("""href="/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui.css"""")
+                assertThat(response).contains("""src="/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui-bundle.js"""")
+                assertThat(response).contains("""src="/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui-standalone-preset.js"""")
+                assertThat(response).contains("""url: '/openapi?v=test'""")
+
+                val otherResponse = Unirest.get("http://localhost:8080/example-ui")
+                    .asString()
+                    .body
+
+                assertThat(otherResponse).contains("""url: '/example-docs?v=test'""")
+            }
+    }
+
+    class ExampleSwaggerPlugin : SwaggerPlugin(
+        SwaggerConfiguration().apply {
+            this.documentationPath = "/example-docs"
+            this.uiPath = "/example-ui"
+        }
+    )
 }

--- a/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
+++ b/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
@@ -191,6 +191,8 @@ class NULL_CLASS
 
 /** Null string because annotations do not support null values */
 const val NULL_STRING = "-- This string represents a null value and shouldn't be used --"
+/** Value to use for auto-generate operationId */
+const val AUTO_STRING = "-- Auto-generate operationId on the fly. If you see this message you are either inspecting via debugger or something went wrong --"
 
 object ContentType {
     const val JSON = "application/json"


### PR DESCRIPTION
Resolves #161

Adds a `catch` to the plugin instance creation that checks if a `GET` handler for the `swaggerWebJarPath` is already present. If the registering of the webjar handler fails for that particular reason, the exception is ignored and otherwise it's rethrown.

Adds appropriate unit test.

