### PR TITLE
GH-161 Check if WebJarHandler is already registered

### DIFF
--- a/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPlugin.kt
+++ b/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPlugin.kt
@@ -41,7 +41,7 @@ open class SwaggerPlugin @JvmOverloads constructor(private val configuration: Sw
 
         /** Register webjar handler if and only if there isn't already a [SwaggerWebJarHandler] at configured route */
         val routes = app.javalinServlet().matcher.findEntries(HandlerType.GET, "${configuration.webJarPath}/*")
-        if(routes.isNotEmpty() && routes.first().handler !is SwaggerWebJarHandler){
+        if(routes.isEmpty() || (routes.isNotEmpty() && routes.first().handler !is SwaggerWebJarHandler)){
             val swaggerWebJarHandler = SwaggerWebJarHandler(
                 swaggerWebJarPath = configuration.webJarPath
             )

--- a/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPlugin.kt
+++ b/javalin-plugins/javalin-swagger-plugin/src/main/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPlugin.kt
@@ -40,13 +40,15 @@ open class SwaggerPlugin @JvmOverloads constructor(private val configuration: Sw
         app.get(configuration.uiPath, swaggerHandler, *configuration.roles)
 
         /** Register webjar handler if and only if there isn't already a [SwaggerWebJarHandler] at configured route */
-        val routes = app.javalinServlet().matcher.findEntries(HandlerType.GET, "${configuration.webJarPath}/*")
-        if(routes.isEmpty() || (routes.isNotEmpty() && routes.first().handler !is SwaggerWebJarHandler)){
-            val swaggerWebJarHandler = SwaggerWebJarHandler(
-                swaggerWebJarPath = configuration.webJarPath
-            )
-            app.get("${configuration.webJarPath}/*", swaggerWebJarHandler, *configuration.roles)
-        }
+        app.javalinServlet().matcher
+            .findEntries(HandlerType.GET, "${configuration.webJarPath}/*")
+            .takeIf { routes -> routes.none { it.handler is SwaggerWebJarHandler } }
+            ?.run {
+                val swaggerWebJarHandler = SwaggerWebJarHandler(
+                    swaggerWebJarPath = configuration.webJarPath
+                )
+                app.get("${configuration.webJarPath}/*", swaggerWebJarHandler, *configuration.roles)
+            }
     }
 
 }

--- a/javalin-plugins/javalin-swagger-plugin/src/test/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPluginTest.kt
+++ b/javalin-plugins/javalin-swagger-plugin/src/test/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPluginTest.kt
@@ -59,34 +59,17 @@ internal class SwaggerPluginTest {
             .start(8080)
             .use{
                 val javalinHost = "http://localhost:8080"
-
-                val webjarCssRoute = "/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui.css"
                 val webjarJsRoute = "/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui-bundle.js"
-                val webjarJsStandaloneRoute = "/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui-standalone-preset.js"
 
                 val response = Unirest.get("$javalinHost/swagger")
                     .asString()
                     .body
 
-                assertThat(response).contains("""href="$webjarCssRoute"""")
                 assertThat(response).contains("""src="$webjarJsRoute"""")
-                assertThat(response).contains("""src="$webjarJsStandaloneRoute"""")
                 assertThat(response).contains("""url: '/openapi?v=test'""")
                 assertThat(response).doesNotContain("""url: '/example-docs?v=test'""")
 
-                var resourceResponse = Unirest.get("$javalinHost$webjarCssRoute")
-                    .asString()
-                    .body
-
-                assertThat(resourceResponse).isNotBlank
-
-                resourceResponse = Unirest.get("$javalinHost$webjarJsRoute")
-                    .asString()
-                    .body
-
-                assertThat(resourceResponse).isNotBlank
-
-                resourceResponse = Unirest.get("$javalinHost$webjarJsStandaloneRoute")
+                val resourceResponse = Unirest.get("$javalinHost$webjarJsRoute")
                     .asString()
                     .body
 

--- a/javalin-plugins/javalin-swagger-plugin/src/test/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPluginTest.kt
+++ b/javalin-plugins/javalin-swagger-plugin/src/test/kotlin/io/javalin/openapi/plugin/swagger/SwaggerPluginTest.kt
@@ -101,6 +101,59 @@ internal class SwaggerPluginTest {
             }
     }
 
+    @Test
+    fun `should not fail if second swagger plugin is registered with routes`(){
+        val swaggerConfiguration = SwaggerConfiguration();
+        val otherConfiguration = ExampleSwaggerPlugin();
+        Javalin.create{
+            it.plugins.register(SwaggerPlugin(swaggerConfiguration))
+            it.plugins.register(otherConfiguration)
+        }.get("/some/route/"){ ctx -> ctx.result("Hello World")}
+            .start(8080)
+            .use{
+                val javalinHost = "http://localhost:8080"
+
+                val webjarCssRoute = "/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui.css"
+                val webjarJsRoute = "/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui-bundle.js"
+                val webjarJsStandaloneRoute = "/webjars/swagger-ui/${swaggerConfiguration.version}/swagger-ui-standalone-preset.js"
+
+                val response = Unirest.get("$javalinHost/swagger")
+                    .asString()
+                    .body
+
+                assertThat(response).contains("""href="$webjarCssRoute"""")
+                assertThat(response).contains("""src="$webjarJsRoute"""")
+                assertThat(response).contains("""src="$webjarJsStandaloneRoute"""")
+                assertThat(response).contains("""url: '/openapi?v=test'""")
+                assertThat(response).doesNotContain("""url: '/example-docs?v=test'""")
+
+                var resourceResponse = Unirest.get("$javalinHost$webjarCssRoute")
+                    .asString()
+                    .body
+
+                assertThat(resourceResponse).isNotBlank
+
+                resourceResponse = Unirest.get("$javalinHost$webjarJsRoute")
+                    .asString()
+                    .body
+
+                assertThat(resourceResponse).isNotBlank
+
+                resourceResponse = Unirest.get("$javalinHost$webjarJsStandaloneRoute")
+                    .asString()
+                    .body
+
+                assertThat(resourceResponse).isNotBlank
+
+                val otherResponse = Unirest.get("$javalinHost/example-ui")
+                    .asString()
+                    .body
+
+                assertThat(otherResponse).contains("""url: '/example-docs?v=test'""")
+                assertThat(otherResponse).doesNotContain("""url: '/openapi?v=test'""")
+            }
+    }
+
     class ExampleSwaggerPlugin : SwaggerPlugin(
         SwaggerConfiguration().apply {
             this.documentationPath = "/example-docs"


### PR DESCRIPTION
Resolves #161 by carefully checking if such a configured `SwaggerWebJarHandler` already exists and if not, registers _one per_ `SwaggerPlugin`. Includes a unit test to demonstrate and confirm the new behaviour.

In the rare circumstance, that someone already would have a non `SwaggerWebJarHanlder` `GET` handler on the configured swagger webjar route, this implementation would -in my opinion- rightfully fail.

Replaces #162  due to polluted git history.