### PR TITLE
GH-232 Allow reference to a model from OpenApiContentProperty

### DIFF
--- a/examples/javalin-gradle-kotlin/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
+++ b/examples/javalin-gradle-kotlin/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
@@ -203,6 +203,7 @@ public final class JavalinTest implements Handler {
                 @OpenApiContent(mimeType = "image/png", type = "string", format = "base64"), // single file upload,
                 @OpenApiContent(mimeType = "multipart/form-data", properties = {
                     @OpenApiContentProperty(name = "form-element", type = "integer"), // random element in form-data
+                    @OpenApiContentProperty(name = "reference", from = KotlinEntity.class), // reference to another object
                     @OpenApiContentProperty(name = "file-name", isArray = true, type = "string", format = "base64") // multi-file upload
                 })
             }

--- a/examples/javalin-maven-java/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
+++ b/examples/javalin-maven-java/src/main/java/io/javalin/openapi/plugin/test/JavalinTest.java
@@ -175,6 +175,7 @@ public final class JavalinTest implements Handler {
                 @OpenApiContent(mimeType = "image/png", type = "string", format = "base64"), // single file upload,
                 @OpenApiContent(mimeType = "multipart/form-data", properties = {
                         @OpenApiContentProperty(name = "form-element", type = "integer"), // random element in form-data
+                        @OpenApiContentProperty(name = "reference", from = KotlinEntity.class) // reference to another object
                         @OpenApiContentProperty(name = "file-name", isArray = true, type = "string", format = "base64") // multi-file upload
                 })
             }

--- a/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/TypeMappersTest.kt
+++ b/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/TypeMappersTest.kt
@@ -197,4 +197,21 @@ internal class TypeMappersTest : OpenApiAnnotationProcessorSpecification() {
             ))
     }
 
+    private class Loop(
+        val self: Loop?,
+    )
+
+
+    @OpenApi(
+        path = "recursive",
+        versions = ["should_map_recursive_type"],
+        responses = [OpenApiResponse(status = "200", content = [OpenApiContent(from = Loop::class)])]
+    )
+    @Test
+    fun should_map_recursive_type() = withOpenApi("should_map_recursive_type") {
+        assertThatJson(it)
+            .inPath("$.components.schemas.Loop.properties.self")
+            .isObject
+            .containsEntry("\$ref", "#/components/schemas/Loop")
+    }
 }

--- a/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
+++ b/openapi-specification/src/main/kotlin/io/javalin/openapi/OpenApiAnnotations.kt
@@ -147,9 +147,10 @@ annotation class OpenApiContent(
 @Target()
 @Retention(RUNTIME)
 annotation class OpenApiContentProperty(
+    val from: KClass<*> = NULL_CLASS::class,
     val name: String,
     val isArray: Boolean = false,
-    val type: String,
+    val type: String = NULL_STRING,
     val format: String = NULL_STRING
 )
 


### PR DESCRIPTION
Hi @dzikoysk,
I faced a need to send complex data along with files in a single request.
OpenAPI specification allows it: https://swagger.io/docs/specification/v3_0/describing-request-body/multipart-requests/

Currently javalin-openapi only allows description of primitive types properties in `multipart/form` content using fields `type` and `format`.
This PR introduces a `from` property to OpenApiPropertyContent annotation. The new `from` property is treated the same way as in `OpenApiContent` (it has higher priority than `type` and `format` and registers referenced type globally).

What do you think?